### PR TITLE
fix validation settings initiation

### DIFF
--- a/behaviors/ConvertableBehavior.php
+++ b/behaviors/ConvertableBehavior.php
@@ -64,6 +64,9 @@ abstract class ConvertableBehavior extends ExtensionBase
             if (!is_array($editorPlugins)) {
                 continue;
             }
+            
+            // prepare tools
+            $this->validationSettings['tools'] = [];
 
             /**
              * @var string $block


### PR DESCRIPTION
When preparing blocks in ConvertableBehaviour, `$this->validationSettings['tools']` is extended as array (`array_add()`) on null, which throws an exception:

> An exception has been thrown during the rendering of a template ("Trying to access array offset on value of type null").

Setting the array before extending it fixes this issue.