### PR TITLE
Add Twig filter |editorjs

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -11,6 +11,7 @@ use ReaZzon\Editor\Classes\Event\ExtendRainLabBlog;
 use ReaZzon\Editor\Classes\Event\ExtendRainLabStaticPages;
 use ReaZzon\Editor\Classes\Event\ExtendIndicatorNews;
 use ReaZzon\Editor\Classes\Event\ExtendLovataGoodNews;
+use ReaZzon\Editor\Behaviors\ConvertToHtml;
 
 /**
  * Editor Plugin Information File
@@ -107,6 +108,19 @@ class Plugin extends PluginBase
             'ReaZzon\Editor\FormWidgets\EditorJS' => 'editorjs',
             'ReaZzon\Editor\FormWidgets\MLEditorJS' => 'mleditorjs',
         ];
+    }
+    
+    public function registerMarkupTags()
+    {
+        return [
+            'filters' => [
+                'editorjs' => [$this, 'convertJsonToHtml']
+            ],
+        ];
+    }
+    
+    public function convertJsonToHtml($field) {
+        return (new ConvertToHtml)->convertJsonToHtml($field);
     }
 
     /**


### PR DESCRIPTION
I needed it for a custom module that I'm developping that allow to use editorJS to any model (even the one coming from another modules where you can't alter the files).

It seems easier to use and implement to use twig filters instead of getMyFieldHtmlAttribute() method to get data from editorjs formwidget. So created a PR that add the feature.

With that PR, you can use |editorjs twig filter to output the value of your model content.

So :
{{ post.content_html|raw }}

Can become : 
{{ post.content|editorjs }}